### PR TITLE
Updated pib-* docker images and upgrade flt cli to latest

### DIFF
--- a/.github/workflows/gitops.yaml
+++ b/.github/workflows/gitops.yaml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Docker Pull
-      run: docker pull ghcr.io/bartr/goa:beta
+      run: docker pull ghcr.io/cse-labs/pib-gitops-automation:beta
 
     - name: Git Config
       run: |
@@ -24,7 +24,7 @@ jobs:
         docker run --rm \
           -v $PWD:/goa/fleet \
           -v $PWD:/goa/control \
-          ghcr.io/retaildevcrews/goa:beta
+          ghcr.io/cse-labs/pib-gitops-automation:beta
 
     - name: Commit GitOps changes
       run: |

--- a/.github/workflows/gitops.yaml
+++ b/.github/workflows/gitops.yaml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Docker Pull
-      run: docker pull ghcr.io/cse-labs/pib-gitops-automation:beta
+      run: docker pull ghcr.io/cse-labs/pib-gitops-automation:latest
 
     - name: Git Config
       run: |
@@ -24,7 +24,7 @@ jobs:
         docker run --rm \
           -v $PWD:/goa/fleet \
           -v $PWD:/goa/control \
-          ghcr.io/cse-labs/pib-gitops-automation:beta
+          ghcr.io/cse-labs/pib-gitops-automation:latest
 
     - name: Commit GitOps changes
       run: |

--- a/apps/dogs-cats/app.yaml
+++ b/apps/dogs-cats/app.yaml
@@ -5,7 +5,7 @@ deployments:
     values:
       app: dogs-cats
       environment: dev
-      image: ghcr.io/cse-labs/go-vote:latest
+      image: ghcr.io/cse-labs/pib-vote:latest
       key1: Dogs
       key2: Cats
       name: dogs-cats

--- a/apps/imdb/app.yaml
+++ b/apps/imdb/app.yaml
@@ -5,8 +5,8 @@ deployments:
     values:
       app: imdb
       environment: dev
-      image: ghcr.io/cse-labs/imdb-app:latest
-      imageName: ghcr.io/cse-labs/imdb-app
+      image: ghcr.io/cse-labs/pib-imdb:latest
+      imageName: ghcr.io/cse-labs/pib-imdb
       imageTag: latest
       name: imdb
       namespace: imdb

--- a/sample-apps/vtlog/app.yaml
+++ b/sample-apps/vtlog/app.yaml
@@ -1,7 +1,7 @@
 app: vtlog
 environment: dev
-image: ghcr.io/retaildevcrews/vtlog:latest
-imageName: ghcr.io/retaildevcrews/vtlog
+image: ghcr.io/cse-labs/pib-tlog:latest
+imageName: ghcr.io/cse-labs/pib-tlog
 imageTag: latest
 name: vtlog
 namespace: vtlog

--- a/templates/pib-service-canary/deploy/webv.yaml
+++ b/templates/pib-service-canary/deploy/webv.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: ghcr.io/retaildevcrews/webv-red:latest
+          image: ghcr.io/cse-labs/pib-webv:latest
           imagePullPolicy: Always
           ports:
             - name: http

--- a/vm/scripts/patch
+++ b/vm/scripts/patch
@@ -1,7 +1,7 @@
 #!/bin/bash
 echo "$(date +'%Y-%m-%d %H:%M:%S')  patched" >> /home/akdc/status
 
-docker pull ghcr.io/cse-labs/webv-red:latest
-docker pull ghcr.io/cse-labs/webv-red:beta
+docker pull ghcr.io/cse-labs/pib-webv:latest
+docker pull ghcr.io/cse-labs/pib-webv:beta
 
 echo "$(hostname) patched"

--- a/vm/setup/akdc-post.sh
+++ b/vm/setup/akdc-post.sh
@@ -6,8 +6,8 @@
 
 echo "$(date +'%Y-%m-%d %H:%M:%S')  akdc-post start" >> "$HOME/status"
 
-docker pull ghcr.io/cse-labs/webv-red:latest
-docker pull ghcr.io/cse-labs/webv-red:beta
+docker pull ghcr.io/cse-labs/pib-webv:latest
+docker pull ghcr.io/cse-labs/pib-webv:beta
 
 kubectl run jumpbox --image=ghcr.io/cse-labs/jumpbox --restart=Always
 


### PR DESCRIPTION
## Purpose of PR

- updated flt version to latest `0.6.2`
- updated docker image references for 
   - pib-imdb
   - pib-webv
   - pib-vote
   - pib-tlog
   - pib-gitops-automation

## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [x] CI-CD changes
- [ ] GitHub Template changes

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/pib-cli/issues/337
- References https://github.com/retaildevcrews/pib-cli/issues/501 https://github.com/retaildevcrews/pib-cli/issues/502
